### PR TITLE
refactor: reduce overall font sizes for better readability

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -15,7 +15,7 @@ export default function Layout({ children }: { children: ReactNode }) {
           <p>
             <Link
               href="/"
-              className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-blue-700 to-blue-500 dark:from-blue-400 dark:to-cyan-400 bg-clip-text text-transparent hover:opacity-80 transition-opacity"
+              className="text-xl sm:text-2xl font-bold bg-gradient-to-r from-blue-700 to-blue-500 dark:from-blue-400 dark:to-cyan-400 bg-clip-text text-transparent hover:opacity-80 transition-opacity"
             >
               {siteTitle}
             </Link>

--- a/pages/articles/[issueNumber].tsx
+++ b/pages/articles/[issueNumber].tsx
@@ -29,7 +29,7 @@ const ShowArticle: NextPage<Props> = ({ issue, issueComments }) => {
               #{issue.number}
             </span>
           </div>
-          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold bg-gradient-to-r from-blue-700 to-blue-500 dark:from-blue-400 dark:to-cyan-400 bg-clip-text text-transparent mb-4 md:mb-6">
+          <h1 className="text-xl sm:text-2xl md:text-3xl font-bold bg-gradient-to-r from-blue-700 to-blue-500 dark:from-blue-400 dark:to-cyan-400 bg-clip-text text-transparent mb-4 md:mb-6">
             {issue.title}
           </h1>
           <aside className="flex flex-wrap items-center gap-2 text-xs sm:text-sm text-gray-600 dark:text-gray-400 bg-gray-50/50 dark:bg-gray-800/50 rounded-lg px-3 sm:px-4 py-2 sm:py-3 backdrop-blur-sm">
@@ -49,11 +49,11 @@ const ShowArticle: NextPage<Props> = ({ issue, issueComments }) => {
             </Link>
           </aside>
         </header>
-        <div className="markdown prose sm:prose-lg dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: issue.bodyHTML }}></div>
+        <div className="markdown prose prose-sm sm:prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: issue.bodyHTML }}></div>
       </article>
       {issueComments.length > 0 && (
         <div className="space-y-4 md:space-y-6">
-          <h2 className="text-xl md:text-2xl font-bold text-gray-900 dark:text-gray-100 px-1 md:px-2">
+          <h2 className="text-lg md:text-xl font-bold text-gray-900 dark:text-gray-100 px-1 md:px-2">
             Comments ({issueComments.length})
           </h2>
           {issueComments.map((issueComment) => (
@@ -61,7 +61,7 @@ const ShowArticle: NextPage<Props> = ({ issue, issueComments }) => {
               key={issueComment.id}
               className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-md rounded-xl p-4 sm:p-6 md:p-8 border border-white/20 dark:border-gray-700/30 shadow-lg"
             >
-              <div className="markdown prose sm:prose-lg dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: issueComment.bodyHTML }} />
+              <div className="markdown prose prose-sm sm:prose dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: issueComment.bodyHTML }} />
             </article>
           ))}
         </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,10 +13,10 @@ const Home: NextPage<Props> = ({ issues }) => {
   return (
     <section>
       <div className="mb-8 md:mb-12">
-        <h1 className="text-3xl sm:text-4xl font-bold bg-gradient-to-r from-blue-700 to-blue-500 dark:from-blue-400 dark:to-cyan-400 bg-clip-text text-transparent mb-3 md:mb-4">
+        <h1 className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-blue-700 to-blue-500 dark:from-blue-400 dark:to-cyan-400 bg-clip-text text-transparent mb-3 md:mb-4">
           Latest Articles
         </h1>
-        <p className="text-gray-600 dark:text-gray-400 text-base md:text-lg">
+        <p className="text-gray-600 dark:text-gray-400 text-sm md:text-base">
           Thoughts, stories and ideas
         </p>
       </div>
@@ -37,10 +37,10 @@ const Home: NextPage<Props> = ({ issues }) => {
                     #{issue.number}
                   </span>
                 </div>
-                <h2 className="text-lg sm:text-xl md:text-2xl font-bold text-gray-900 dark:text-gray-100 group-hover:bg-gradient-to-r group-hover:from-blue-700 group-hover:to-blue-500 dark:group-hover:from-blue-400 dark:group-hover:to-cyan-400 group-hover:bg-clip-text group-hover:text-transparent transition-all duration-300">
+                <h2 className="text-base sm:text-lg md:text-xl font-bold text-gray-900 dark:text-gray-100 group-hover:bg-gradient-to-r group-hover:from-blue-700 group-hover:to-blue-500 dark:group-hover:from-blue-400 dark:group-hover:to-cyan-400 group-hover:bg-clip-text group-hover:text-transparent transition-all duration-300">
                   {issue.title}
                 </h2>
-                <div className="flex items-center gap-2 text-sm text-blue-600 dark:text-blue-400 font-medium mt-1">
+                <div className="flex items-center gap-2 text-xs sm:text-sm text-blue-600 dark:text-blue-400 font-medium mt-1">
                   <span>Read more</span>
                   <svg className="w-4 h-4 transform group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />


### PR DESCRIPTION
## Summary

Reduce all font sizes across the site based on user feedback that text was too large.

## Changes

### Site Logo
- text-2xl sm:text-3xl → text-xl sm:text-2xl

### Page Header (Latest Articles)
- text-3xl sm:text-4xl → text-2xl sm:text-3xl
- Subtitle: text-base md:text-lg → text-sm md:text-base

### Article List
- Title: text-lg sm:text-xl md:text-2xl → text-base sm:text-lg md:text-xl
- "Read more": text-sm → text-xs sm:text-sm

### Article Detail
- Title: text-2xl sm:text-3xl md:text-4xl → text-xl sm:text-2xl md:text-3xl
- Body: prose sm:prose-lg → prose-sm sm:prose
- Comments heading: text-xl md:text-2xl → text-lg md:text-xl
- Comment body: prose sm:prose-lg → prose-sm sm:prose

## Benefits

- ✅ More comfortable reading experience
- ✅ Better information density
- ✅ Maintains hierarchy and readability
- ✅ More professional appearance