### PR TITLE
chore(ci): update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,21 +12,21 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: data
           ref: data
         continue-on-error: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20.17.0"
+          node-version: "22.21.1"
           cache: npm
       - run: npm install
       - run: npm run export
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: out

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,22 +25,22 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           path: data
           ref: data
         continue-on-error: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20.17.0"
+          node-version: "22.21.1"
           cache: npm
       - run: npm install
       - name: Sync GitHub Issues to Markdown
         run: npm run sync-issues
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@v4
         with:
           destination_dir: .
           disable_nojekyll: true
@@ -49,7 +49,7 @@ jobs:
           publish_branch: data
           publish_dir: data
       - run: npm run export
-      - uses: peaceiris/actions-gh-pages@v3
+      - uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22.21.1"
           cache: npm
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload visual diffs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-diffs
           path: test-results/


### PR DESCRIPTION
## Summary
- Update `actions/checkout` v4 → v6
- Update `actions/setup-node` v4 → v6
- Update `peaceiris/actions-gh-pages` v3 → v4
- Update `actions/upload-artifact` v4 → v7
- Update `node-version` 20.17.0 → 22.21.1 in publish/sync workflows

Resolves Node.js 20 deprecation warnings in CI.

## Test plan
- [ ] CI workflows run without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)